### PR TITLE
fix: update mason plugin reference

### DIFF
--- a/tools/nvim/lua/plugins/mason.lua
+++ b/tools/nvim/lua/plugins/mason.lua
@@ -2,7 +2,7 @@ local diagnostics = vim.g.lazyvim_rust_diagnostics or "rust-analyzer"
 
 return {
   {
-    "williamboman/mason.nvim",
+    "mason-org/mason.nvim",
     optional = true,
     opts = function(_, opts)
       opts.ensure_installed = opts.ensure_installed or {}


### PR DESCRIPTION
## Summary
- point the mason plugin to the `mason-org/mason.nvim` repository to silence the warning

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e122b1da80832583fe492ba64c84a5