### PR TITLE
Derive Treesitter parser list from available parsers

### DIFF
--- a/tools/nvim/lua/plugins/treesitter.lua
+++ b/tools/nvim/lua/plugins/treesitter.lua
@@ -2,8 +2,9 @@ return {
   -- add more treesitter parsers
   {
     'nvim-treesitter/nvim-treesitter',
-    opts = {
-      ensure_installed = 'all'
-    },
+    opts = function(_, opts)
+      opts.ensure_installed = require('nvim-treesitter.parsers').available_parsers()
+      return opts
+    end,
   },
 }


### PR DESCRIPTION
## Summary
- set the nvim-treesitter ensure_installed option to the list of available parsers so the configuration still uses a table while covering all maintained grammars

## Testing
- not run (Neovim not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e122b33dbc8325ad611518ba88d3e6