### PR TITLE
feat: configure nvim-tree to open on right side

### DIFF
--- a/tools/nvim/lua/plugins/tree.lua
+++ b/tools/nvim/lua/plugins/tree.lua
@@ -28,6 +28,7 @@ return {
       },
       view = {
         width = '20%',
+        side = 'right',
         signcolumn = 'no',
       },
       renderer = {


### PR DESCRIPTION
## Summary
- configure nvim-tree view to render on the right side of the window

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e12d3ea384832585c1a33446babced