### PR TITLE
Guard treesitter parser lookup when plugin missing

### DIFF
--- a/tools/nvim/lua/plugins/treesitter.lua
+++ b/tools/nvim/lua/plugins/treesitter.lua
@@ -3,7 +3,15 @@ return {
   {
     'nvim-treesitter/nvim-treesitter',
     opts = function(_, opts)
-      opts.ensure_installed = require('nvim-treesitter.parsers').available_parsers()
+      opts.ensure_installed = type(opts.ensure_installed) == 'table' and opts.ensure_installed or {}
+
+      local ok, parsers = pcall(require, 'nvim-treesitter.parsers')
+      if ok and type(parsers) == 'table' and type(parsers.available_parsers) == 'function' then
+        local available = parsers.available_parsers()
+        if type(available) == 'table' then
+          opts.ensure_installed = available
+        end
+      end
       return opts
     end,
   },


### PR DESCRIPTION
## Summary
- guard the treesitter parser require so the configuration loads even when the plugin is absent
- retain existing ensure_installed values unless the parser list is successfully retrieved

## Testing
- nvim --headless "+Lazy sync" +qa *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e12f975f048325985afa86fa7c5b93